### PR TITLE
Feature/update elixir 1.9.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.8.0-otp-21
-erlang 21.1.1
+elixir 1.9.0-otp-22
+erlang 22.0.5

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :connex, Connex.PoolTest,
   pools: [


### PR DESCRIPTION
* Elixir 1.9.0 へアップデートしました。
* Mix.Config がdeprecatedになったのでConfigを使うように修正しました。